### PR TITLE
Update replicaset.md for Issue #12205 with k8s.io/docs/concepts/workloads/controllers/replicaset/ 

### DIFF
--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -137,6 +137,8 @@ created the other pods. Kubernetes does not stop you from doing this.
 If you do end up with multiple controllers that have overlapping selectors, you
 will have to manage the deletion yourself.
 
+Note: For 2 ReplicaSet specifying the same `.spec.selector` but different `.spec.template.metadata.labels` and `.spec.template.spec`, each ReplicaSet ignores the pods created by another and controller creates the Replicas.
+
 ### Labels on a ReplicaSet
 
 The ReplicaSet can itself have labels (`.metadata.labels`).  Typically, you

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -137,7 +137,9 @@ created the other pods. Kubernetes does not stop you from doing this.
 If you do end up with multiple controllers that have overlapping selectors, you
 will have to manage the deletion yourself.
 
-Note: For 2 ReplicaSet specifying the same `.spec.selector` but different `.spec.template.metadata.labels` and `.spec.template.spec`, each ReplicaSet ignores the pods created by another and controller creates the Replicas.
+{{< note >}}
+For 2 ReplicaSet specifying the same `.spec.selector` but different `.spec.template.metadata.labels` and `.spec.template.spec`, each ReplicaSet ignores the pods created by another and controller creates the Replicas.
+{{< /note >}}
 
 ### Labels on a ReplicaSet
 

--- a/content/en/docs/concepts/workloads/controllers/replicaset.md
+++ b/content/en/docs/concepts/workloads/controllers/replicaset.md
@@ -138,7 +138,7 @@ If you do end up with multiple controllers that have overlapping selectors, you
 will have to manage the deletion yourself.
 
 {{< note >}}
-For 2 ReplicaSet specifying the same `.spec.selector` but different `.spec.template.metadata.labels` and `.spec.template.spec`, each ReplicaSet ignores the pods created by another and controller creates the Replicas.
+For 2 ReplicaSet specifying the same `.spec.selector` but different `.spec.template.metadata.labels` and `.spec.template.spec`, each ReplicaSet ignores the Pods created by another and controller creates the Replicas.
 {{< /note >}}
 
 ### Labels on a ReplicaSet


### PR DESCRIPTION
Overview :  This pull request is for Issue #12205 which updates the replicaset.md file

When ReplicaSets have the same label selectors but different metadata, the Replicas are created by controller because each Replicaset ignores the Pods created by another.
